### PR TITLE
some initial adjustments

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,13 @@ about:
   license_family: Other
   license_file: COPYING.txt
   summary: Qhull computes the convex hull
+  description: |
+    Qhull computes the convex hull, Delaunay triangulation, Voronoi diagram, halfspace
+    intersection about a point, furthest-site Delaunay triangulation, and furthest-site
+    Voronoi diagram. The source code runs in 2-d, 3-d, 4-d, and higher dimensions. Qhull
+    implements the Quickhull algorithm for computing the convex hull. It handles roundoff
+    errors from floating point arithmetic. It computes volumes, surface areas, and
+    approximations to the convex hull.
   doc_url: https://www.qhull.org/html
   dev_url: https://github.com/qhull/qhull
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,9 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    - make  # [unix]
+    - make      # [unix]
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
   run:
 
@@ -49,11 +51,12 @@ test:
     - rbox 1000 D3 | qhull C-1e-4 FO Ts
 
 about:
-  home: http://www.qhull.org/
+  home: https://www.qhull.org/
   license: Qhull
+  license_family: Other
   license_file: COPYING.txt
   summary: Qhull computes the convex hull
-  doc_url: http://www.qhull.org/html
+  doc_url: https://www.qhull.org/html
   dev_url: https://github.com/qhull/qhull
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ test:
     - rbox 1000 D3 | qhull C-1e-4 FO Ts
 
 about:
-  home: https://www.qhull.org/
+  home: http://www.qhull.org/
   license: Qhull
   license_family: Other
   license_file: COPYING.txt
@@ -63,7 +63,7 @@ about:
     implements the Quickhull algorithm for computing the convex hull. It handles roundoff
     errors from floating point arithmetic. It computes volumes, surface areas, and
     approximations to the convex hull.
-  doc_url: https://www.qhull.org/html
+  doc_url: http://www.qhull.org/html
   dev_url: https://github.com/qhull/qhull
 
 extra:


### PR DESCRIPTION
do an initial build for it
we need it for more recent gdal updates.  Interestingly is project's home-page not providing https in a secured way.  So I am not sure here, if we should still provide the https:// links, or for those links here http:// instead